### PR TITLE
gometalint is deprecated, use golangci-lint instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,18 +65,17 @@ RUN set -e \
     go get -u -v github.com/josharian/impl && \
     go get -u -v github.com/haya14busa/goplay/cmd/goplay && \
     go get -u -v github.com/davidrjenni/reftools/cmd/fillstruct && \
-    go get -u -v github.com/alecthomas/gometalinter && \
     go get -u -v github.com/go-delve/delve/cmd/dlv && \
     go get -u -v github.com/rogpeppe/godef && \
     go get -u -v github.com/uudashr/gopkgs/cmd/gopkgs && \
     go get -u -v golang.org/x/tools/cmd/gotype && \
     GO111MODULE=on go get -v golang.org/x/tools/gopls@latest && \
     go build -o /go/bin/gocode-gomod github.com/stamblerre/gocode && \
-    gometalinter --install && \
     chmod -R 777 "$GOPATH" && \
     apk del .build-deps && \
     mkdir /.cache && chmod -R 777 /.cache && \
-    apk add gcc g++ git
+    apk add gcc g++ git && \
+    wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.22.2
 
 ENV GOPATH /go
 ENV GOCACHE /.cache


### PR DESCRIPTION
Signed-off-by: Esteban Mañaricua emanaricua@gmail.com

use golangci-lint instead of deprecated gometalint