### PR TITLE
gopls needs to create content in /.cache

### DIFF
--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -22,7 +22,7 @@ fi
 
 # Grant access to projects volume in case of non root user with sudo rights
 if [ "${USER_ID}" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /dev/null 2>&1; then
-    sudo chown "${USER_ID}:${GROUP_ID}" /projects
+    sudo chown "${USER_ID}:${GROUP_ID}" /projects /.cache
 fi
 
 exec "$@"


### PR DESCRIPTION
Signed-off-by: Esteban Mañaricua <emanaricua@gmail.com>

gopls needs ownership over /.cache to create new content.
fixes: [#16929](https://github.com/eclipse/che/issues/16929) "peek definition" and import hints not working.

Signed-off-by: Esteban Mañaricua <emanaricua@gmail.com>