### PR TITLE
Turn off GO111MODULE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,9 @@ RUN set -e -x && \
     mkdir -p /usr/local/go && chmod -R 777 /usr/local/go && \
     cd /usr/local/go && wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.22.2
 
-ENV GOPATH /go
 ENV GOCACHE /.cache
 ENV GOROOT /usr/local/go
-ENV GO111MODULE on
+ENV GO111MODULE off
 
 ADD etc/entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Removes declaring of GOPATH as it already defined in the base image.

Turns off GO111MODULE, prevents appearing of error message from Go language server with a proposal to update.

![Screenshot from 2020-07-14 14-19-58](https://user-images.githubusercontent.com/1655894/87420542-26a54b80-c5de-11ea-8946-2bbcd8a8c769.png)

Devfile to test

```
---
apiVersion: 1.0.0
metadata:
  generateName: golang-
projects:
-
  name: example
  source:
    type: git
    location: https://github.com/golang/example.git
  clonePath: src/github.com/golang/example/

components:

-
  type: chePlugin
  reference: >-
    https://gist.githubusercontent.com/vitaliy-guliy/7206986ae2f2bdde55fabab7dcd3a9ed/raw/8b1d33434e241225a59d24a0c9f38535691a47cd/meta.yaml
-
  type: dockerimage
  image: quay.io/eclipse/che-golang-1.14:nightly
  alias: go-cli
  env:
    - name: GOPATH
      # replicate the GOPATH from the plugin
      value: /go:$(CHE_PROJECTS_ROOT)
    - name: GOCACHE
      # replicate the GOCACHE from the plugin, even though the cache is not shared
      # between the two
      value: /tmp/.cache
  endpoints:
    - name: '8080-tcp'
      port: 8080
  memoryLimit: 512Mi
  mountSources: true

commands:
-
  name: run outyet
  actions:
  - type: exec
    component: go-cli
    command: go get -d && go run main.go
    workdir: ${CHE_PROJECTS_ROOT}/src/github.com/golang/example/outyet
-
  name: stop outyet
  actions:
  - type: exec
    component: go-cli
    command: kill $(pidof go)
-
  name: test outyet
  actions:
  - type: exec
    component: go-cli
    command: go test
    workdir: ${CHE_PROJECTS_ROOT}/src/github.com/golang/example/outyet
-
  name: run current file
  actions:
  - type: exec
    component: go-cli
    command: go get -d && go run ${file}
    workdir: ${fileDirname}
-
  name: Debug current file
  actions:
  - type: vscode-launch
    referenceContent: |
      {
        "version": "0.2.0",
        "configurations": [
          {
            "name": "Debug current file",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "${fileDirname}"
          }
        ]
      }

```
